### PR TITLE
Enhancements and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 aws-ocp4-config-*
 ocp4-sandbox*
-auth/group-cluster-admins.yaml
-auth/users.htpasswd
+!auth/*.example
+auth/*group-cluster-admins.yaml
+auth/*.htpasswd

--- a/auth/users.htpasswd.example
+++ b/auth/users.htpasswd.example
@@ -1,0 +1,1 @@
+redhat:$2y$05$66ymwy5ydAx5Uj0Px.j/fOC8IeG6ttJKKC/mi2Gcb/vYI42tCMW4K


### PR DESCRIPTION
### Description of Changes

This PR includes the following updates and improvements:

- **Fix for Infinite Loop in Login Script**: Resolved an issue where attempting to log in with the `redhat` user would result in an infinite loop if the user did not exist. Additionally, the subsequent conditional fallback check would not have been evaluated correctly. 
Introduced a configurable maximum number of login attempts to handle this scenario gracefully.  
- **Example File for Default `redhat` User**: Added a sample file containing credentials for the default `redhat` user already provided in the script. This allows repository users to use this account without the need to create an `htpasswd` file manually, saving time during setup.  
- **Customizable Paths for `htpasswd` and `group-cluster-admins`**: Added support for specifying custom paths for `htpasswd` and `group-cluster-admins` files via environment variables. The default behavior remains unchanged, ensuring backward compatibility while allowing greater flexibility for users with different configurations.  
- **Reusable `oc` Function**: Introduced a helper function for running `oc` commands to eliminate repetitive code and improve maintainability.  
- **Dynamic Display of Login Information**: Updated the final informational output to dynamically show the active user (`redhat` or `kubeadmin`) based on the login flow outcome.  
- **`.gitignore` handling**: Enabled the possibility to include additional files in the `auth` directory.

### Testing

Both login flows (`redhat` and `kubeadmin`) have been thoroughly tested. All changes have been validated, and the installation process is confirmed to be successful.
